### PR TITLE
fix(ui-ux): nav bar UI between `lg` and `xl` width 

### DIFF
--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -59,14 +59,14 @@ export function Header(): JSX.Element {
               />
             </div>
           </Link>
-          <div className="hidden lg:flex">
+          <div className="hidden xl:flex">
             <DesktopNavbar />
           </div>
           <div className="flex">
-            <div className="hidden lg:flex">
+            <div className="hidden xl:flex">
               <HeaderNetworkMenu />
             </div>
-            <div className="lg:hidden">
+            <div className="xl:hidden">
               <div className="mr-1.5 md:mr-0">
                 <FiMenu
                   className="w-6 h-6 stroke-white-50"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- As titled, to fix:
<img width="882" alt="image" src="https://user-images.githubusercontent.com/40191153/201630740-2f6d51b5-0c81-4288-9f2d-751b2437b414.png">

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
