### PR TITLE
feat(ui-ux): handle lost block details and display block hash

### DIFF
--- a/src/api/BlocksApi.ts
+++ b/src/api/BlocksApi.ts
@@ -29,8 +29,11 @@ export default {
   ): Promise<BlockProps> => {
     const baseUrl = getBaseUrl(network);
     const res = await fetch(`${baseUrl}/${MAIN_BLOCKS_URL}/${blockId}`);
-
-    return wrapResponse<BlockProps>(res);
+    const block = (await await res.json()) as BlockProps;
+    if (!res.ok && !block.hash) {
+      throw new Error(`Failed to fetch data: ${res.status}`);
+    }
+    return block;
   },
   getBlockTransactions: async (
     network: NetworkConnection,

--- a/src/api/BlocksApi.ts
+++ b/src/api/BlocksApi.ts
@@ -29,7 +29,7 @@ export default {
   ): Promise<BlockProps> => {
     const baseUrl = getBaseUrl(network);
     const res = await fetch(`${baseUrl}/${MAIN_BLOCKS_URL}/${blockId}`);
-    const block = (await await res.json()) as BlockProps;
+    const block = (await res.json()) as BlockProps;
     if (!res.ok && !block.hash) {
       throw new Error(`Failed to fetch data: ${res.status}`);
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -188,6 +188,7 @@ export interface BlockProps {
   gas_used: string;
   gas_used_percentage: number;
   height: number;
+  hash: string;
   miner: {
     hash: string;
   };

--- a/src/pages/block/[id].tsx
+++ b/src/pages/block/[id].tsx
@@ -1,32 +1,30 @@
 import BigNumber from "bignumber.js";
-import clsx from "clsx";
 import { utils } from "ethers";
-import { useEffect, useState } from "react";
-import { FiArrowLeft, FiArrowRight, FiCopy } from "react-icons/fi";
-import { MdCheckCircle } from "react-icons/md";
+import { FiArrowLeft, FiArrowRight } from "react-icons/fi";
 import {
   GetServerSidePropsContext,
   GetServerSidePropsResult,
   InferGetServerSidePropsType,
 } from "next";
 import GradientCardContainer from "@components/commons/GradientCardContainer";
-import LinkText from "@components/commons/LinkText";
 import LinkTextWithIcon from "@components/commons/LinktextWithIcon";
 import NumericFormat from "@components/commons/NumericFormat";
 import TransactionDetails from "@components/TransactionDetails";
-import useCopyToClipboard from "hooks/useCopyToClipboard";
 import { SearchBar } from "layouts/components/searchbar/SearchBar";
 import {
   formatDateToUTC,
   getDuration,
   getTimeAgo,
 } from "shared/durationHelper";
-import { isNumeric, truncateTextFromMiddle } from "shared/textHelper";
+import { isNumeric } from "shared/textHelper";
 import { getRewards } from "shared/getRewards";
 import { NetworkConnection } from "@contexts/Environment";
 import BlocksApi from "@api/BlocksApi";
 import { TxnNextPageParamsProps } from "@api/TransactionsApi";
 import { BlockProps, RawTransactionI } from "@api/types";
+import AddressRow from "./_components/AddressRow";
+import DetailRow from "./_components/DetailRow";
+import GasUsedRow from "./_components/GasUsedRow";
 
 interface PageProps {
   block: BlockProps;
@@ -113,12 +111,20 @@ export default function Block({
           <div className="border-t border-black-600 pt-8 text-white-50 flex flex-col md:flex-row md:gap-5">
             <div className="w-full md:w-1/2">
               <AddressRow
-                label="Fee recipient"
-                feeRecipient={block.miner.hash}
+                testId="block-hash"
+                label="Hash"
+                address={block.hash}
+                disableLink
               />
               <AddressRow
+                testId="fee-recipient"
+                label="Fee recipient"
+                address={block.miner.hash}
+              />
+              <AddressRow
+                testId="parent-hash"
                 label="Parent Hash"
-                feeRecipient={block.parent_hash}
+                address={block.parent_hash}
               />
               <DetailRow
                 testId="block-size"
@@ -186,138 +192,6 @@ export default function Block({
             </div>
           </div>
         </GradientCardContainer>
-      </div>
-    </div>
-  );
-}
-
-const style = {
-  container: "flex gap-5 py-3 md:gap-0",
-  labelWidth: "w-1/2 md:shrink-0 lg:w-1/3",
-  valueWidth: "flex-1 text-right md:text-left",
-};
-
-function DetailRow({
-  testId,
-  label,
-  value,
-  decimalScale = 8,
-  suffix = "",
-}: {
-  testId: string;
-  label: string;
-  value: string;
-  decimalScale?: number;
-  suffix?: string;
-}): JSX.Element {
-  return (
-    <div className={clsx(style.container)}>
-      <div
-        data-testid={`${testId}-label`}
-        className={clsx("text-white-700", style.labelWidth)}
-      >
-        {label}
-      </div>
-      <div
-        data-testid={testId}
-        className={clsx("text-white-50", style.valueWidth)}
-      >
-        <NumericFormat
-          thousandSeparator
-          value={value}
-          decimalScale={decimalScale}
-          suffix={suffix}
-        />
-      </div>
-    </div>
-  );
-}
-
-function AddressRow({
-  label,
-  feeRecipient,
-}: {
-  label: string;
-  feeRecipient: string;
-}): JSX.Element {
-  const { copy } = useCopyToClipboard();
-  const [showSuccessCopy, setShowSuccessCopy] = useState(false);
-
-  useEffect(() => {
-    if (showSuccessCopy) {
-      setTimeout(() => setShowSuccessCopy(false), 3000);
-    }
-  }, [showSuccessCopy]);
-
-  return (
-    <div className={clsx("justify-between md:justify-start", style.container)}>
-      <div
-        data-testid="fee-recipient-label"
-        className={clsx("text-white-700", style.labelWidth)}
-      >
-        {label}
-      </div>
-      {showSuccessCopy ? (
-        <div data-testid="copy-success-msg" className="flex items-center">
-          <span className="text-lightBlue">Copied!</span>
-          <MdCheckCircle size={20} className="ml-2 text-green-800" />
-        </div>
-      ) : (
-        <div className="flex">
-          <LinkText
-            testId="fee-recipient-mobile"
-            href={`/address/${feeRecipient}`}
-            label={truncateTextFromMiddle(feeRecipient, 4)}
-            customStyle={clsx("inline-flex xl:hidden", style.valueWidth)}
-          />
-          <LinkText
-            testId="fee-recipient-desktop"
-            href={`/address/${feeRecipient}`}
-            label={truncateTextFromMiddle(feeRecipient, 13)}
-            customStyle={clsx("hidden xl:inline-flex", style.valueWidth)}
-          />
-          <FiCopy
-            size={20}
-            className="ml-2 self-center cursor-pointer"
-            onClick={() => {
-              copy(feeRecipient);
-              setShowSuccessCopy(true);
-            }}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
-
-function GasUsedRow({
-  label,
-  gasUsed,
-  gasPercentage,
-}: {
-  label: string;
-  gasUsed: string;
-  gasPercentage: string;
-}): JSX.Element {
-  return (
-    <div className={clsx(style.container)}>
-      <div
-        data-testid="gas-used-label"
-        className={clsx("text-white-700", style.labelWidth)}
-      >
-        {label}
-      </div>
-      <div className={clsx(style.valueWidth)}>
-        <div data-testid="gas-used" className="text-white-50">
-          <NumericFormat
-            thousandSeparator
-            value={new BigNumber(gasUsed)}
-            decimalScale={0}
-          />
-        </div>
-        <div data-testid="gas-pct" className="text-white-700 text-xs pt-1">
-          {gasPercentage}%
-        </div>
       </div>
     </div>
   );

--- a/src/pages/block/_components/AddressRow.tsx
+++ b/src/pages/block/_components/AddressRow.tsx
@@ -1,0 +1,78 @@
+import clsx from "clsx";
+import { useEffect, useState } from "react";
+import { FiCopy } from "react-icons/fi";
+import { MdCheckCircle } from "react-icons/md";
+import useCopyToClipboard from "@hooks/useCopyToClipboard";
+import LinkText from "@components/commons/LinkText";
+import { truncateTextFromMiddle } from "shared/textHelper";
+
+export default function AddressRow({
+  label,
+  address,
+  testId,
+  disableLink,
+}: {
+  label: string;
+  address: string;
+  testId: string;
+  disableLink?: boolean;
+}): JSX.Element {
+  const { copy } = useCopyToClipboard();
+  const [showSuccessCopy, setShowSuccessCopy] = useState(false);
+
+  useEffect(() => {
+    if (showSuccessCopy) {
+      setTimeout(() => setShowSuccessCopy(false), 3000);
+    }
+  }, [showSuccessCopy]);
+
+  const style = {
+    container: "flex gap-5 py-3 md:gap-0",
+    labelWidth: "w-1/2 md:shrink-0 lg:w-1/3",
+    valueWidth: "flex-1 text-right md:text-left",
+  };
+
+  return (
+    <div className={clsx("justify-between md:justify-start", style.container)}>
+      <div
+        data-testid={`${testId}-label`}
+        className={clsx("text-white-700", style.labelWidth)}
+      >
+        {label}
+      </div>
+      {showSuccessCopy ? (
+        <div data-testid="copy-success-msg" className="flex items-center">
+          <span className="text-lightBlue">Copied!</span>
+          <MdCheckCircle size={20} className="ml-2 text-green-800" />
+        </div>
+      ) : (
+        <div className="flex">
+          <LinkText
+            testId={`${testId}-mobile`}
+            href={`/address/${address}`}
+            label={truncateTextFromMiddle(address, 4)}
+            customStyle={clsx("inline-flex xl:hidden", style.valueWidth, {
+              "text-white-50 pointer-events-none": disableLink,
+            })}
+          />
+          <LinkText
+            testId={`${testId}-desktop`}
+            href={`/address/${address}`}
+            label={truncateTextFromMiddle(address, 13)}
+            customStyle={clsx("hidden xl:inline-flex", style.valueWidth, {
+              "text-white-50 pointer-events-none": disableLink,
+            })}
+          />
+          <FiCopy
+            size={20}
+            className="ml-2 self-center cursor-pointer"
+            onClick={() => {
+              copy(address);
+              setShowSuccessCopy(true);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/block/_components/DetailRow.tsx
+++ b/src/pages/block/_components/DetailRow.tsx
@@ -1,0 +1,44 @@
+import clsx from "clsx";
+import NumericFormat from "@components/commons/NumericFormat";
+
+export default function DetailRow({
+  testId,
+  label,
+  value,
+  decimalScale = 8,
+  suffix = "",
+}: {
+  testId: string;
+  label: string;
+  value: string;
+  decimalScale?: number;
+  suffix?: string;
+}): JSX.Element {
+  const style = {
+    container: "flex gap-5 py-3 md:gap-0",
+    labelWidth: "w-1/2 md:shrink-0 lg:w-1/3",
+    valueWidth: "flex-1 text-right md:text-left",
+  };
+
+  return (
+    <div className={clsx(style.container)}>
+      <div
+        data-testid={`${testId}-label`}
+        className={clsx("text-white-700", style.labelWidth)}
+      >
+        {label}
+      </div>
+      <div
+        data-testid={testId}
+        className={clsx("text-white-50", style.valueWidth)}
+      >
+        <NumericFormat
+          thousandSeparator
+          value={value}
+          decimalScale={decimalScale}
+          suffix={suffix}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/block/_components/GasUsedRow.tsx
+++ b/src/pages/block/_components/GasUsedRow.tsx
@@ -1,0 +1,42 @@
+import BigNumber from "bignumber.js";
+import clsx from "clsx";
+import NumericFormat from "@components/commons/NumericFormat";
+
+export default function GasUsedRow({
+  label,
+  gasUsed,
+  gasPercentage,
+}: {
+  label: string;
+  gasUsed: string;
+  gasPercentage: string;
+}): JSX.Element {
+  const style = {
+    container: "flex gap-5 py-3 md:gap-0",
+    labelWidth: "w-1/2 md:shrink-0 lg:w-1/3",
+    valueWidth: "flex-1 text-right md:text-left",
+  };
+
+  return (
+    <div className={clsx(style.container)}>
+      <div
+        data-testid="gas-used-label"
+        className={clsx("text-white-700", style.labelWidth)}
+      >
+        {label}
+      </div>
+      <div className={clsx(style.valueWidth)}>
+        <div data-testid="gas-used" className="text-white-50">
+          <NumericFormat
+            thousandSeparator
+            value={new BigNumber(gasUsed)}
+            decimalScale={0}
+          />
+        </div>
+        <div data-testid="gas-pct" className="text-white-700 text-xs pt-1">
+          {gasPercentage}%
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tx/_components/GasDetails.tsx
+++ b/src/pages/tx/_components/GasDetails.tsx
@@ -55,14 +55,9 @@ export default function GasDetails({
             label="Gas price"
             tooltip="Cost per unit of gas specified for the transaction"
           >
-            <NumericFormat
-              data-testid="gas-price"
-              className={rowValueFont}
-              thousandSeparator
-              value={gasPrice.value}
-              decimalScale={0}
-              suffix={` ${gasPrice.symbol}`}
-            />
+            <span data-testid="gas-price" className={rowValueFont}>
+              {gasPrice.value} {gasPrice.symbol}
+            </span>
           </DetailRow>
           <DetailRow
             label="Gas limit"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Handle reorganized block - redirect to `block/hash` to display details page (eg.: block 5475)
- Display block hash on block details page
- Retain decimals for gas price in block details

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #216 

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
