### PR TITLE
fix(ui-ux): tx for contract creation - to is incorrect

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -104,6 +104,17 @@ export interface RawTxnWithPaginationProps {
   };
 }
 
+export interface CreatedContractProps {
+  hash: string;
+  implementation_name?: string;
+  is_contract: boolean;
+  is_verified?: boolean;
+  name: string;
+  privateTags: [];
+  public_tags: [];
+  watchlist_names: [];
+}
+
 export interface RawTransactionI {
   tx_types: string[];
   type: number;
@@ -129,6 +140,7 @@ export interface RawTransactionI {
   method: string | null;
   confirmations: number;
   token_transfers?: any;
+  created_contract?: CreatedContractProps;
 }
 
 export interface TokenTransferProps {

--- a/src/pages/tx/[tid].tsx
+++ b/src/pages/tx/[tid].tsx
@@ -190,7 +190,11 @@ export default function Transaction({
                 customStyle="tracking-[0.01em]"
                 testId="transaction-details-from"
                 label={truncateTextFromMiddle(txDetails.from, 4)}
-                href={`/address/${txDetails.from}`}
+                href={
+                  txDetails.isFromContract
+                    ? `/contract/${txDetails.from}`
+                    : `/address/${txDetails.from}`
+                }
               />
             </WithCopy>
           </DetailRow>
@@ -211,7 +215,11 @@ export default function Transaction({
                   customStyle="tracking-[0.01em]"
                   testId="transaction-details-to"
                   label={truncateTextFromMiddle(txDetails.to, 4)}
-                  href={`/address/${txDetails.to}`}
+                  href={
+                    txDetails.isToContract
+                      ? `/contract/${txDetails.to}`
+                      : `/address/${txDetails.to}`
+                  }
                 />
               </WithCopy>
             </DetailRow>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
The to is displaying a burn hash instead of the created contract address

wrong
<img width="627" alt="image" src="https://github.com/BirthdayResearch/metascan/assets/13292662/b62e8031-922d-49ed-83fd-5af402f98e90">

Correct
<img width="703" alt="image" src="https://github.com/BirthdayResearch/metascan/assets/13292662/43492372-bf22-4d49-9369-82e84db69a4f">

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
