### PR TITLE
fix(ui-ux): fix displayed read methods that are actually write methods

### DIFF
--- a/src/pages/address/_components/contract/ReadWriteContract.tsx
+++ b/src/pages/address/_components/contract/ReadWriteContract.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
-import { ContractMethodType, SmartContractMethod } from "@api/types";
+import {
+  ContractMethodType,
+  SmartContractMethod,
+  StateMutability,
+} from "@api/types";
 import { useNetwork } from "@contexts/NetworkContext";
 import { useGetContractMethodsMutation } from "@store/contract";
 import { FiLoader } from "react-icons/fi";
@@ -33,26 +37,15 @@ export default function ReadWriteContract({
       type,
     }).unwrap();
 
-    /**
-     * Workaround that manually filters out methods that are not part of `read` methods
-     * TODO: Check in blockscout api why `read` is returning all functions including write
-     */
     if (
       type === ContractMethodType.Read ||
       type === ContractMethodType.ReadProxy
     ) {
-      const writeMethods = await trigger({
-        network: connection,
-        addressHash,
-        type:
-          type === ContractMethodType.Read
-            ? ContractMethodType.Write
-            : ContractMethodType.WriteProxy,
-      }).unwrap();
       // Filter out read methods that are also in write methods
-      const readMethods = data.filter(
-        (readMethod) =>
-          !writeMethods.some((write) => write.name === readMethod.name)
+      const readMethods = data.filter((method) =>
+        [StateMutability.Pure, StateMutability.View].includes(
+          method.stateMutability
+        )
       );
       setMethods(readMethods ?? []);
       setIsLoading(false);

--- a/src/pages/address/_components/contract/ReadWriteContract.tsx
+++ b/src/pages/address/_components/contract/ReadWriteContract.tsx
@@ -34,7 +34,7 @@ export default function ReadWriteContract({
     }).unwrap();
 
     /**
-     * Work-around that manually filters out methods that are not part of `read` methods
+     * Workaround that manually filters out methods that are not part of `read` methods
      * TODO: Check in blockscout api why `read` is returning all functions including write
      */
     if (

--- a/src/pages/address/_components/contract/ReadWriteContract.tsx
+++ b/src/pages/address/_components/contract/ReadWriteContract.tsx
@@ -41,12 +41,12 @@ export default function ReadWriteContract({
       type === ContractMethodType.Read ||
       type === ContractMethodType.ReadProxy
     ) {
-      // Filter out read methods that are also in write methods
       const readMethods = data.filter((method) =>
         [StateMutability.Pure, StateMutability.View].includes(
           method.stateMutability
         )
       );
+
       setMethods(readMethods ?? []);
       setIsLoading(false);
       return;

--- a/src/pages/address/_components/contract/ReadWriteContract.tsx
+++ b/src/pages/address/_components/contract/ReadWriteContract.tsx
@@ -50,9 +50,8 @@ export default function ReadWriteContract({
             : ContractMethodType.WriteProxy,
       }).unwrap();
       // Filter out read methods that are also in write methods
-      const readMethods = data.filter(
-        (readMethod) =>
-          writeMethods.findIndex((write) => write.name === readMethod.name) < 0
+      const readMethods = data.filter((readMethod) =>
+        writeMethods.some((write) => write.name === readMethod.name)
       );
       setMethods(readMethods ?? []);
       setIsLoading(false);

--- a/src/pages/address/_components/contract/ReadWriteContract.tsx
+++ b/src/pages/address/_components/contract/ReadWriteContract.tsx
@@ -50,8 +50,9 @@ export default function ReadWriteContract({
             : ContractMethodType.WriteProxy,
       }).unwrap();
       // Filter out read methods that are also in write methods
-      const readMethods = data.filter((readMethod) =>
-        writeMethods.some((write) => write.name === readMethod.name)
+      const readMethods = data.filter(
+        (readMethod) =>
+          !writeMethods.some((write) => write.name === readMethod.name)
       );
       setMethods(readMethods ?? []);
       setIsLoading(false);

--- a/src/pages/address/_components/contract/ReadWriteContract.tsx
+++ b/src/pages/address/_components/contract/ReadWriteContract.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import { ContractMethodType } from "@api/types";
+import { useEffect, useState } from "react";
+import { ContractMethodType, SmartContractMethod } from "@api/types";
 import { useNetwork } from "@contexts/NetworkContext";
-import { useGetContractMethodsQuery } from "@store/contract";
+import { useGetContractMethodsMutation } from "@store/contract";
 import { FiLoader } from "react-icons/fi";
 import LinkText from "@components/commons/LinkText";
 import ContractMethod from "./ContractMethod";
@@ -18,14 +18,54 @@ export default function ReadWriteContract({
   addressHash: string;
   implementationAddress: string | null;
 }) {
+  const [isLoading, setIsLoading] = useState(true);
   const [expandAll, setExpandAll] = useState<boolean>(false);
   const [resetForm, setResetForm] = useState<boolean>(false);
   const { connection } = useNetwork();
-  const { data: methods, isLoading } = useGetContractMethodsQuery({
-    network: connection,
-    addressHash,
-    type,
-  });
+  const [trigger] = useGetContractMethodsMutation();
+  const [methods, setMethods] = useState<SmartContractMethod[]>([]);
+
+  const fetchMethods = async () => {
+    setIsLoading(true);
+    const data = await trigger({
+      network: connection,
+      addressHash,
+      type,
+    }).unwrap();
+
+    /**
+     * Work-around that manually filters out methods that are not part of `read` methods
+     * TODO: Check in blockscout api why `read` is returning all functions including write
+     */
+    if (
+      type === ContractMethodType.Read ||
+      type === ContractMethodType.ReadProxy
+    ) {
+      const writeMethods = await trigger({
+        network: connection,
+        addressHash,
+        type:
+          type === ContractMethodType.Read
+            ? ContractMethodType.Write
+            : ContractMethodType.WriteProxy,
+      }).unwrap();
+      // Filter out read methods that are also in write methods
+      const readMethods = data.filter(
+        (readMethod) =>
+          writeMethods.findIndex((write) => write.name === readMethod.name) < 0
+      );
+      setMethods(readMethods ?? []);
+      setIsLoading(false);
+      return;
+    }
+
+    setMethods(data ?? []);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    fetchMethods();
+  }, []);
 
   // TODO: Add UI loaders
   if (isLoading) {

--- a/src/store/contract.ts
+++ b/src/store/contract.ts
@@ -83,7 +83,7 @@ export const contractMethodsApi = createApi({
   reducerPath: "contractMethods",
   baseQuery: fetchBaseQuery({ baseUrl: "/" }),
   endpoints: (builder) => ({
-    getContractMethods: builder.query<
+    getContractMethods: builder.mutation<
       SmartContractMethod[],
       {
         network: NetworkConnection;
@@ -118,5 +118,5 @@ export const contractVerificationApi = createApi({
 });
 
 export const { useGetContractQuery } = contractApi;
-export const { useGetContractMethodsQuery } = contractMethodsApi;
+export const { useGetContractMethodsMutation } = contractMethodsApi;
 export const { useGetVerificationConfigQuery } = contractVerificationApi;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
For smart contract, there are `read` methods returned by blockscout api that is actually write method, so this PR is a work-around to manually filter out those write methods from read methods section.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
